### PR TITLE
Fix npe when chaining assoc

### DIFF
--- a/src/borkdude/rewrite_edn/impl.cljc
+++ b/src/borkdude/rewrite_edn/impl.cljc
@@ -36,7 +36,7 @@
 
 (defn assoc
   [forms k v]
-  (let [zloc (z/edn forms)
+  (let [zloc (z/edn forms {:track-position? true})
         tag (z/tag zloc)
         zloc (z/skip z/right (fn [zloc]
                                (let [t (z/tag zloc)]
@@ -64,8 +64,9 @@
       (let [zloc (z/down zloc)
             zloc (skip-right zloc)
             ;; the location of the first key:
-            first-key-loc (when-let [first-key (z/node zloc)]
-                            (meta first-key))]
+            first-key-loc (when (z/node zloc)
+                            (let [[row col] (z/position zloc)]
+                              {:row row :col col}))]
         (loop [key-count 0
                zloc zloc]
           (if (and (#{:token :map} tag) (z/rightmost? zloc))

--- a/test/borkdude/rewrite_edn_test.cljc
+++ b/test/borkdude/rewrite_edn_test.cljc
@@ -65,7 +65,13 @@
     (is (try
           (r/assoc (r/parse-string "[9 8 3 #_99 #_213 7] ;; this is a cool vector") 4 99)
           false
-          (catch java.lang.IndexOutOfBoundsException _ true)))))
+          (catch java.lang.IndexOutOfBoundsException _ true))))
+  (testing "Chained assoc"
+    (is (= "{:a 1\n :b 2}"
+           (-> (r/parse-string "{}")
+               (r/assoc :a 1)
+               (r/assoc :b 2)
+               str)))))
 
 (deftest update-test
   (is (= "{:a #_:foo 2}"


### PR DESCRIPTION
When chaining `assoc`s calls a NullPointerException is thrown. This happens because rewrite-clj only adds the position metadata when parsing the initial string. Using `:track-position?` (https://cljdoc.org/d/rewrite-clj/rewrite-clj/1.0.767-alpha/doc/user-guide#position-tracking) fixes the issue.