### PR TITLE
Bump deps

### DIFF
--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [#20](https://github.com/borkdude/rewrite-edn/issues/20): Bump rewrite-clj to v1.1.45 ([@lread](https://github.com/lread))
 - [#19](https://github.com/borkdude/rewrite-edn/issues/19): Repeated `assoc-in`, `assoc` no longer throw `NullPointerException` ([@lread](https://github.com/lread))
 - Add `keys`
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,7 @@
-{:deps {rewrite-clj/rewrite-clj {:mvn/version "1.0.572-alpha"}}
+{:deps {rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}}
  :aliases {:test
            {:extra-deps
             {org.clojure/clojure {:mvn/version "1.9.0"}
-             cognitect/test-runner
-             {:git/url "https://github.com/cognitect-labs/test-runner"
-              :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
+             io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
             :extra-paths ["test"]
             :main-opts ["-m" "cognitect.test-runner"]}}}

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :url "http://opensource.org/licenses/eclipse-1.0.php"}
   :source-paths ["src"]
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [rewrite-clj "1.0.572-alpha"]]
+                 [rewrite-clj "1.1.45"]]
   ;; :plugins [[lein-codox "0.10.7"]]
   ;; :codox {:output-path "gh-pages"}
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"

--- a/src/borkdude/rewrite_edn/impl.cljc
+++ b/src/borkdude/rewrite_edn/impl.cljc
@@ -40,7 +40,7 @@
 
 (defn assoc*
   [forms k v]
-  (let [zloc (z/edn forms)
+  (let [zloc (z/of-node forms)
         tag (z/tag zloc)
         zloc (z/skip z/right (fn [zloc]
                                (let [t (z/tag zloc)]
@@ -115,7 +115,7 @@
       mark-for-positional-recalc))
 
 (defn get [zloc k default]
-  (let [zloc (z/edn zloc)
+  (let [zloc (z/of-node zloc)
         tag (z/tag zloc)]
     (cond
       (= tag :map)
@@ -165,7 +165,7 @@
           zloc ks))
 
 (defn update [forms k f]
-  (let [zloc (z/edn forms)
+  (let [zloc (z/of-node forms)
         zloc (z/skip z/right (fn [zloc]
                                (let [t (z/tag zloc)]
                                  (not (contains? #{:token :map} t)))) zloc)
@@ -215,7 +215,7 @@
             (mark-for-positional-recalc)))))
 
 (defn map-keys [f forms]
-  (let [zloc (z/edn forms)
+  (let [zloc (z/of-node forms)
         zloc (if (= :map (z/tag zloc))
                zloc
                (z/skip z/right (fn [zloc]
@@ -236,7 +236,7 @@
                      (skip-right))))))))
 
 (defn dissoc [forms k]
-  (let [zloc (z/edn forms)
+  (let [zloc (z/of-node forms)
         zloc (z/skip z/right (fn [zloc]
                                (let [t (z/tag zloc)]
                                  (not (contains? #{:token :map} t)))) zloc)
@@ -261,7 +261,7 @@
                            (skip-right)))))))))))
 
 (defn keys [forms]
-  (let [zloc (z/edn forms)
+  (let [zloc (z/of-node forms)
         zloc (if (= :map (z/tag zloc))
                zloc
                (z/skip z/right (fn [zloc]


### PR DESCRIPTION
Include rewrite-clj clj-kondo config.

Adapt to deprecated rewrite-clj.zip/edn.
It was renamed to rewrite-clj.zip/of-node.

Closes #20