### PR TITLE
Add cljs conditional to fix undeclared var for java warning

### DIFF
--- a/src/borkdude/rewrite_edn/impl.cljc
+++ b/src/borkdude/rewrite_edn/impl.cljc
@@ -63,7 +63,8 @@
           (z/append-child (node/coerce v))
           (z/root))
       out-of-bounds?
-      (throw (java.lang.IndexOutOfBoundsException.))
+      (throw #?(:clj (java.lang.IndexOutOfBoundsException.)
+                :cljs (ex-info "IndexOutOfBounds" {})))
       :else
       (let [zloc (z/down zloc)
             zloc (skip-right zloc)


### PR DESCRIPTION
Hi @borkdude. We're using rewrite-edn for cljs and the latest rewrite-edn has this warning:
```
------ WARNING #2 - :undeclared-var -------------------------------------------
 Resource: borkdude/rewrite_edn/impl.cljc:66:14
 Use of undeclared Var borkdude.rewrite-edn.impl/java
```
Happy to tweak the PR if you'd like different behavior. Cheers