### PR TITLE
`assoc`/`update` now handles zero-indent keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 [rewrite-clj](https://github.com/clj-commons/rewrite-clj) with common operations
 to update EDN while preserving whitespace and comments.
 
+## Unreleased
+
+- [#40](https://github.com/borkdude/rewrite-edn/issues/40): `assoc`/`update` now handles map keys that have no indent at all ([@lread](https://github.com/lread))
+
 ## 0.4.8
 
 - Add newline after adding new element to top level map with `assoc-in`

--- a/test/borkdude/rewrite_edn_test.cljc
+++ b/test/borkdude/rewrite_edn_test.cljc
@@ -31,6 +31,13 @@
 {:a 1}
 ;; this is a cool map")
                  :b 2)))))
+  (testing "we vertically align map to first key even when not indented"
+    (is (= "{
+:a 1
+:b 2}"
+           (str (r/assoc (r/parse-string "{
+:a 1}")
+                         :b 2)))))
   (testing "Updating existing val"
     (is (= "{:a 2}"
            (str (r/assoc
@@ -88,7 +95,25 @@
                (r/parse-string "{:a #_:foo 1}")
                :a (fn [node]
                     (inc (r/sexpr node)))))))
-  ;; unlike assoc, update does not currently indent a new item
+  (testing "align with first keyword in map"
+    (is (= "{ :a 3
+  :b 1}"
+           (-> "{ :a 0}"
+               r/parse-string
+               (r/update :a (constantly 3))
+               (r/update :b (constantly 1))
+               str))))
+  (testing "align even when keyword not indented"
+    (is (= "{
+:a 3
+:b 1}"
+           (-> "{
+:a 0}"
+               r/parse-string
+               (r/update :a (constantly 3))
+               (r/update :b (constantly 1))
+               str))))
+  ;; unlike assoc, update does not currently indent when all items are new (yet)
   (is (= "{:a 0 :b 1}"
          (-> "{}"
              r/parse-string


### PR DESCRIPTION
Contributes to #40

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/borkdude/rewrite-edn/blob/master/CHANGELOG.md) file with a description of the addressed issue.
