### PR TITLE
Align to comment/uneval for "empty" maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ to update EDN while preserving whitespace and comments.
 
 ## Unreleased
 
-- [#40](https://github.com/borkdude/rewrite-edn/issues/40): `assoc`/`update` now handles map keys that have no indent at all ([@lread](https://github.com/lread))
+- [#40](https://github.com/borkdude/rewrite-edn/issues/40): `assoc`/`update` now handles map keys that have no indent at all 
+([@lread](https://github.com/lread))
+- [#40](https://github.com/borkdude/rewrite-edn/issues/40): `assoc`/`update` now aligns indent to comment if that's all that is in the map
+([@lread](https://github.com/lread))
+- [#40](https://github.com/borkdude/rewrite-edn/issues/40): `update` now indents new entries in same way as `assoc`
+([@lread](https://github.com/lread))
 
 ## 0.4.8
 


### PR DESCRIPTION
If an empty map only has comments and/or #_ unevals, align assoc'ed entry to first comment (or uneval).

To help me test this fix, also fixed alignment for `update` when map is empty by applying existing technique I saw for `assoc` -> `assoc*`.

Closes #40

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/borkdude/rewrite-edn/blob/master/CHANGELOG.md) file with a description of the addressed issue.
